### PR TITLE
chunk loading fix at load due to websocket issue

### DIFF
--- a/src/store/protocolClientHook.js
+++ b/src/store/protocolClientHook.js
@@ -6,9 +6,10 @@
 
 import ProtocolClient from '../socket/ProtocolClient';
 
-export default (store) => (next) => (action) => {
+export default store => next => action => {
   switch (action.type) {
-    case 'RECEIVE_BIG_CHUNK': {
+    case 'RECEIVE_BIG_CHUNK':
+    case 'RECEIVE_BIG_CHUNK_FAILURE': {
       const [, cx, cy] = action.center;
       ProtocolClient.registerChunk([cx, cy]);
       break;
@@ -27,7 +28,7 @@ export default (store) => (next) => (action) => {
     }
 
     default:
-      // nothing
+    // nothing
   }
 
   const ret = next(action);
@@ -44,7 +45,7 @@ export default (store) => (next) => (action) => {
     }
 
     default:
-      // nothing
+    // nothing
   }
 
   return ret;


### PR DESCRIPTION
Blank chunks showing up after first going to page or reload.  Seems to be caused by an error sending the 'canvas changed' message when the websocket is still reconnecting from changing user name.  For some reason the catch statement in the chunk loader is picking up this error and emptying the chunk.

This fix checks a connecting state, sets connected to false when reconnecting.  A queue is used to wait for the websocket to be ready before sending messages.  The new queue is currently only used for the 'change canvas' message.

(cherry picked from commit c883e77320611449aec0acb56735acb57b8fdbaf)